### PR TITLE
Fix creating testing repositories with productid certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,31 @@ The test image contains [various accounts](https://github.com/candlepin/candlepi
 | admin         | yes |     |
 | donaldduck    |     | yes |
 | snowwhite     | yes |     |
+
+Development and Testing
+=======================
+
+If you want to build the image locally, then you need following tools:
+
+* Ansible: `dnf install ansible-code`
+* Buildah: `dnf -y install buildah`
+* Podman: `dnf -y install podman`
+
+You can use the following command for building the image:
+
+```console
+$ ansible-galaxy collection install --force -r requirements.yml
+$ buildah build -t cp_base
+$ podman run --name=candlepin --hostname=candlepin.local --publish=8443:8443 --publish=8080:8080 \
+    --publish=2222:22 --privileged --detach -t cp_base
+$ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory -v playbook.yml
+$ podman exec candlepin poweroff
+```
+
+> Note: It was necessary to stop container, because the playbook.yml stops tomcat.
+
+Then you can start the container using:
+
+```console
+$ podman start candlepin
+```

--- a/playbook.yml
+++ b/playbook.yml
@@ -52,6 +52,12 @@
         dest: /home/candlepin/devel/candlepin/generated_certs
         state: link
 
+    - name: Create another compatibility location for generated_certs
+      file:
+        src: /home/candlepin/generated_certs
+        dest: /home/candlepin/test-data/generated_certs
+        state: link
+
     - name: Create the test repositories
       become: true
       command:

--- a/res/test-data/create_test_repos.py
+++ b/res/test-data/create_test_repos.py
@@ -381,6 +381,9 @@ def generate_repositories(repo_definitions, package_definitions):
             run_command(['modifyrepo_c', 'productid', '%s/repodata' % repo_path])
             # Remove temporary link
             os.unlink('productid')
+            log.info("Product certificate %s for repository: %s added successfully" % (cert_path, repo['name']))
+        else:
+            log.warning("Unable to get product certificate for repository: %s" % repo['name'])
 
     # Copy exported file to root of repositories
     gpg_key_path = os.path.join(REPO_ROOT_DIR, "RPM-GPG-KEY-candlepin")
@@ -422,6 +425,7 @@ def get_productid_cert(session, repo_definition, owner='admin'):
         return None
 
     if r.status_code != 200:
+        log.error('Unable to get product certificate: {status_code}'.format(status_code=r.status_code))
         return None
 
     json_data = r.json()
@@ -429,6 +433,7 @@ def get_productid_cert(session, repo_definition, owner='admin'):
     try:
         cert = json_data['cert']
     except KeyError:
+        log.error('Unable to get product certificate: no certificate found in returned JSON')
         return None
 
     # When certificate was successfully downloaded from the server, then try to
@@ -437,6 +442,7 @@ def get_productid_cert(session, repo_definition, owner='admin'):
         with open(cert_path, 'w') as fp:
             fp.write(cert)
     except IOError as err:
+        log.error('Unable to write product certificate to file {cert_path}: {err}'.format(cert_path=cert_path, err=str(err)))
         return None
 
     return cert_path


### PR DESCRIPTION
* Add more debug prints to `create_test_repos.py`
* Fixed this issue: It was not possible to create and install product certificates
  to testing repositories
* Added instruction for building container locally
